### PR TITLE
Updated to not use extras 'range' function

### DIFF
--- a/time.zig
+++ b/time.zig
@@ -186,7 +186,7 @@ pub const DateTime = struct {
 
     pub fn dayOfThisYear(self: Self) u16 {
         var ret: u16 = 0;
-        for (0..self.months, 0..) |_, item| {
+        for (0..self.months) |item| {
             ret += self.daysInMonth(@intCast(u16, item));
         }
         ret += self.days;

--- a/time.zig
+++ b/time.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const string = []const u8;
-const range = extras.range;
 const extras = @import("extras");
 const time = @This();
 
@@ -187,7 +186,7 @@ pub const DateTime = struct {
 
     pub fn dayOfThisYear(self: Self) u16 {
         var ret: u16 = 0;
-        for (range(self.months), 0..) |_, item| {
+        for (0..self.months, 0..) |_, item| {
             ret += self.daysInMonth(@intCast(u16, item));
         }
         ret += self.days;

--- a/zig.mod
+++ b/zig.mod
@@ -3,5 +3,6 @@ name: time
 main: time.zig
 license: MIT
 description: A date and time parsing and formatting library for Zig.
+min_zig_version: 0.11.0-dev.1681+0bb178bbb
 dependencies:
   - src: git https://github.com/nektro/zig-extras


### PR DESCRIPTION
Was unable to build because of dependency on "range", created a PR similar to https://github.com/nektro/zig-extras/commit/1da74fba8c47fde0af1459afa152742821590100