### PR TITLE
fix: updated build system to use v0.11.0 modules

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,11 +1,24 @@
 const std = @import("std");
-const deps = @import("./deps.zig");
 
 pub fn build(b: *std.build.Builder) void {
+    const extras = b.dependency("extras", .{});
+    const time = b.addModule(
+        "time",
+        .{
+            .source_file = .{ .path = "time.zig" },
+            .dependencies = &.{
+                .{
+                    .name = "extras",
+                    .module = extras.module("extras"),
+                },
+            },
+        },
+    );
+
     const t = b.addTest(.{
         .root_source_file = .{ .path = "main.zig" },
     });
-    deps.addAllTo(t);
+    t.addModule("time", time);
 
     const run_t = b.addRunArtifact(t);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,10 @@
+.{
+    .name = "time",
+    .version = "0.1.0",
+    .dependencies = .{
+        .extras = .{
+            .url = "https://github.com/nektro/zig-extras/archive/master.tar.gz",
+            .hash = "12203cc9c306e25cafb7ff99a317cb5a402f42dd257fbb26ef6126c7e009742d1712",
+        } 
+    }
+}


### PR DESCRIPTION
Needs https://github.com/nektro/zig-extras/pull/3 merged first

Added a modules wrapper for zig-time so it can be used in Zig 0.11.0 projects. Tests all still pass.

Todo: 

- [ ] update `build.zig.zon` after https://github.com/nektro/zig-extras/pull/3 merged.