### PR TITLE
Update format printer to correctly print hours.

### DIFF
--- a/time.zig
+++ b/time.zig
@@ -279,8 +279,8 @@ pub const DateTime = struct {
                     .HH => try writer.print("{:0>2}", .{self.hours}),
                     .h => try writer.print("{}", .{wrap(self.hours, 12)}),
                     .hh => try writer.print("{:0>2}", .{wrap(self.hours, 12)}),
-                    .k => try writer.print("{}", .{wrap(self.hours, 24)}),
-                    .kk => try writer.print("{:0>2}", .{wrap(self.hours, 24)}),
+                    .k => try writer.print("{}", .{wrap(self.hours, 23)}),
+                    .kk => try writer.print("{:0>2}", .{wrap(self.hours, 23)}),
 
                     .m => try writer.print("{}", .{self.minutes}),
                     .mm => try writer.print("{:0>2}", .{self.minutes}),


### PR DESCRIPTION
Fix the formatter to correctly print hours. For example 24:53 isn't a real time as it would be the next day and the correct time would be 00:53 or 23:53. This could also point to a bug 